### PR TITLE
chore: fixed error to members.ts

### DIFF
--- a/src/content/members.ts
+++ b/src/content/members.ts
@@ -344,9 +344,9 @@ export const members: Member[] = [
 },
 {
     name: "Eitan Seri-Levi",
-    link: "https://github.com/@eserilev",
-    username: "@eserilev",
-    pfp: "https://avatars.githubusercontent.com/@eserilev"
+    link: "https://github.com/eserilev",
+    username: "eserilev",
+    pfp: "https://avatars.githubusercontent.com/eserilev"
 },
 {
     name: "Enrico Del Fante",
@@ -662,9 +662,9 @@ export const members: Member[] = [
 },
 {
     name: "Mark Holt",
-    link: "https://github.com/@mh0lt",
-    username: "@mh0lt",
-    pfp: "https://avatars.githubusercontent.com/@mh0lt"
+    link: "https://github.com/mh0lt",
+    username: "mh0lt",
+    pfp: "https://avatars.githubusercontent.com/mh0lt"
 },
 {
     name: "Mark Mackey",


### PR DESCRIPTION
Hi! I fixed formatting issues in the `members.ts` file where GitHub profile links and usernames were incorrectly prefixed with an `@`, which caused broken links and invalid avatar URLs.
